### PR TITLE
Update appointment-related classes and add list-appointments feature

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -110,9 +110,9 @@ public class Messages {
     public static String format(Appointment appointment) {
         final StringBuilder builder = new StringBuilder();
         builder.append("; Dentist: ")
-            .append(appointment.getDentist())
+            .append(appointment.getDentistName())
             .append("; Patient: ")
-            .append(appointment.getPatient())
+            .append(appointment.getPatientName())
             .append("; Appointment: ")
             .append(appointment.getAppointmentTime().startToString())
             .append("; Duration: ")

--- a/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
@@ -7,10 +7,14 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SERVICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START;
 
+import java.util.function.Predicate;
+
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointments.Appointment;
+import seedu.address.model.person.dentist.Dentist;
+import seedu.address.model.person.patients.Patient;
 
 
 /**
@@ -38,7 +42,8 @@ public class AddAppointmentCommand extends Command {
     public static final String MESSAGE_CLASHING_APPOINTMENTS = "This Appointment clashes with a current one.";
 
     private final Appointment toAdd;
-
+    private final long dentistId;
+    private final long patientId;
     /**
      * Constructs an AddAppointmentCommand with the specified appointment.
      *
@@ -47,6 +52,8 @@ public class AddAppointmentCommand extends Command {
     public AddAppointmentCommand(Appointment appointment) {
         requireNonNull(appointment);
         toAdd = appointment;
+        dentistId = appointment.getDentist();
+        patientId = appointment.getPatient();
     }
 
 
@@ -63,6 +70,27 @@ public class AddAppointmentCommand extends Command {
         if (model.hasAppointment(toAdd)) {
             throw new CommandException(MESSAGE_CLASHING_APPOINTMENTS);
         }
+
+        if (dentistId >= 0) {
+            Predicate<Dentist> dentistIdPredicate = dentist -> dentist.getId() == dentistId;
+            model.updateFilteredDentistList(dentistIdPredicate);
+
+            if (model.getFilteredDentistList().isEmpty()) {
+                throw new CommandException("No dentist with ID " + dentistId);
+            }
+
+        }
+
+        if (patientId >= 0) {
+            Predicate<Patient> patientIdPredicate = patient -> patient.getId() == patientId;
+            model.updateFilteredPatientList(patientIdPredicate);
+
+            if (model.getFilteredPatientList().isEmpty()) {
+                throw new CommandException("No patient with ID " + dentistId);
+            }
+
+        }
+
         model.addAppointment(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }

--- a/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
@@ -39,11 +39,11 @@ public class AddAppointmentCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New Appointment added: %1$s";
 
-    public static final String MESSAGE_CLASHING_DOCTORS = "This doctor already has a " +
-            "current appointment in the same time slot.";
+    public static final String MESSAGE_CLASHING_DOCTORS = "This doctor already has a "
+            + "current appointment in the same time slot.";
 
-    public static final String MESSAGE_CLASHING_PATIENTS = "This patient already has a " +
-            "current appointment in the same time slot.";
+    public static final String MESSAGE_CLASHING_PATIENTS = "This patient already has a "
+            + "current appointment in the same time slot.";
 
     private final Appointment toAdd;
     private final long dentistId;

--- a/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
@@ -39,7 +39,7 @@ public class AddAppointmentCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New Appointment added: %1$s";
 
-    public static final String MESSAGE_CLASHING_DOCTORS = "This doctor already has a "
+    public static final String MESSAGE_CLASHING_DOCTORS = "This dentist already has a "
             + "current appointment in the same time slot.";
 
     public static final String MESSAGE_CLASHING_PATIENTS = "This patient already has a "
@@ -56,8 +56,8 @@ public class AddAppointmentCommand extends Command {
     public AddAppointmentCommand(Appointment appointment) {
         requireNonNull(appointment);
         toAdd = appointment;
-        dentistId = appointment.getDentist();
-        patientId = appointment.getPatient();
+        dentistId = appointment.getDentistId();
+        patientId = appointment.getPatientId();
     }
 
 
@@ -79,6 +79,9 @@ public class AddAppointmentCommand extends Command {
             if (model.getFilteredDentistList().isEmpty()) {
                 throw new CommandException("No dentist with ID " + dentistId);
             }
+
+            Dentist dentist = model.getFilteredDentistList().get(0);
+            toAdd.setDentistName(dentist.getName().fullName);
         }
 
         if (patientId >= 0) {
@@ -88,6 +91,8 @@ public class AddAppointmentCommand extends Command {
             if (model.getFilteredPatientList().isEmpty()) {
                 throw new CommandException("No patient with ID " + dentistId);
             }
+            Patient patient = model.getFilteredPatientList().get(0);
+            toAdd.setPatientName(patient.getName().fullName);
         }
 
         if (model.hasAppointment(toAdd)) {
@@ -96,7 +101,7 @@ public class AddAppointmentCommand extends Command {
 
             if (!model.getFilteredAppointmentList().isEmpty()) {
                 for (int i = 0; i < model.getFilteredAppointmentList().size(); i++) {
-                    if (model.getFilteredAppointmentList().get(i).getDentist() == dentistId) {
+                    if (model.getFilteredAppointmentList().get(i).getDentistId() == dentistId) {
                         throw new CommandException(MESSAGE_CLASHING_DOCTORS);
                     }
                 }
@@ -104,7 +109,7 @@ public class AddAppointmentCommand extends Command {
 
             if (!model.getFilteredAppointmentList().isEmpty()) {
                 for (int i = 0; i < model.getFilteredAppointmentList().size(); i++) {
-                    if (model.getFilteredAppointmentList().get(i).getPatient() == patientId) {
+                    if (model.getFilteredAppointmentList().get(i).getPatientId() == patientId) {
                         throw new CommandException(MESSAGE_CLASHING_PATIENTS);
                     }
                 }

--- a/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
@@ -31,15 +31,19 @@ public class AddAppointmentCommand extends Command {
             + PREFIX_DURATION + "DURATION "
             + PREFIX_SERVICE + "SERVICE \n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_DENTIST + "TOM "
-            + PREFIX_PATIENT + "JOHN "
+            + PREFIX_DENTIST + "0 "
+            + PREFIX_PATIENT + "0 "
             + PREFIX_START + "2023-10-12 16:00 "
             + PREFIX_DURATION + "PT1H30M "
             + PREFIX_SERVICE + "Braces";
 
     public static final String MESSAGE_SUCCESS = "New Appointment added: %1$s";
 
-    public static final String MESSAGE_CLASHING_APPOINTMENTS = "This Appointment clashes with a current one.";
+    public static final String MESSAGE_CLASHING_DOCTORS = "This doctor already has a " +
+            "current appointment in the same time slot.";
+
+    public static final String MESSAGE_CLASHING_PATIENTS = "This patient already has a " +
+            "current appointment in the same time slot.";
 
     private final Appointment toAdd;
     private final long dentistId;
@@ -93,7 +97,15 @@ public class AddAppointmentCommand extends Command {
             if (!model.getFilteredAppointmentList().isEmpty()) {
                 for (int i = 0; i < model.getFilteredAppointmentList().size(); i++) {
                     if (model.getFilteredAppointmentList().get(i).getDentist() == dentistId) {
-                        throw new CommandException(MESSAGE_CLASHING_APPOINTMENTS);
+                        throw new CommandException(MESSAGE_CLASHING_DOCTORS);
+                    }
+                }
+            }
+
+            if (!model.getFilteredAppointmentList().isEmpty()) {
+                for (int i = 0; i < model.getFilteredAppointmentList().size(); i++) {
+                    if (model.getFilteredAppointmentList().get(i).getPatient() == patientId) {
+                        throw new CommandException(MESSAGE_CLASHING_PATIENTS);
                     }
                 }
             }

--- a/src/main/java/seedu/address/logic/commands/ListAppointmentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAppointmentsCommand.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
+
+import seedu.address.model.Model;
+
+public class ListAppointmentsCommand extends Command {
+
+    public static final String COMMAND_WORD = "list-appointments";
+
+    public static final String MESSAGE_SUCCESS = "Listed all appointments!";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ListAppointmentsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAppointmentsCommand.java
@@ -5,6 +5,9 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
 
 import seedu.address.model.Model;
 
+/**
+ * Lists all appointments in ToothTracker to the user.
+ */
 public class ListAppointmentsCommand extends Command {
 
     public static final String COMMAND_WORD = "list-appointments";

--- a/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/CommandException.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands.exceptions;
 
 /**
- * Represents an error which occurs during execution of a {@link Command}.
+ * Represents an error which occurs during execution of a {@link CommandException}.
  */
 public class CommandException extends Exception {
     public CommandException(String message) {

--- a/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
@@ -37,8 +37,8 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
                     AddAppointmentCommand.MESSAGE_USAGE));
         }
 
-        String dentist = argMultimap.getValue(PREFIX_DENTIST).get();
-        String patient = argMultimap.getValue(PREFIX_PATIENT).get();
+        long dentist = Long.parseLong(argMultimap.getValue(PREFIX_DENTIST).get());
+        long patient = Long.parseLong(argMultimap.getValue(PREFIX_PATIENT).get());
         String start = argMultimap.getValue(PREFIX_START).get();
         String[] parts = start.split("\\s+");
         String startParsed = null;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditDentistCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListAppointmentsCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListDentistsCommand;
 import seedu.address.logic.commands.ListPatientCommand;
@@ -98,6 +99,9 @@ public class AddressBookParser {
 
         case ListDentistsCommand.COMMAND_WORD:
             return new ListDentistsCommand();
+
+        case ListAppointmentsCommand.COMMAND_WORD:
+            return new ListAppointmentsCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -352,6 +352,7 @@ public class AddressBook implements ReadOnlyAddressBook {
             .add("persons", persons)
             .add("patients", patients)
             .add("dentists", dentists)
+            .add("appointments", appointments)
             .add("treatments", treatments)
             .toString();
     }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -24,6 +24,7 @@ public interface Model {
     Predicate<Patient> PREDICATE_SHOW_ALL_PATIENTS = unused -> true;
     Predicate<Dentist> PREDICATE_SHOW_ALL_DENTISTS = unused -> true;
     Predicate<Treatment> PREDICATE_SHOW_ALL_TREATMENTS = unused -> true;
+    Predicate<Appointment> PREDICATE_SHOW_ALL_APPOINTMENTS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -180,6 +180,8 @@ public interface Model {
 
     void updateFilteredDentistList(NameContainsKeywordsPredicate predicate);
 
+    void updateFilteredAppointmentList(Predicate<Appointment> predicate);
+
     /**
      * Adds the given Treatment. {@code Treatment} must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -281,6 +281,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void updateFilteredAppointmentList(Predicate<Appointment> predicate) {
+        requireNonNull(predicate);
+        filteredAppointments.setPredicate(predicate);
+    }
+
+    @Override
     public boolean hasTreatment(Treatment treatment) {
         requireNonNull(treatment);
         return addressBook.hasTreatment(treatment);

--- a/src/main/java/seedu/address/model/appointments/Appointment.java
+++ b/src/main/java/seedu/address/model/appointments/Appointment.java
@@ -1,29 +1,35 @@
 package seedu.address.model.appointments;
 
+import seedu.address.model.person.Name;
+import seedu.address.model.person.dentist.Dentist;
+import seedu.address.model.person.patients.Patient;
+
 /**
  * Represents an Appointment in ToothTracker.
  */
 public class Appointment {
-    private final long dentist;
-    private final long patient;
+    private final long dentistId;
+    private final long patientId;
     private final AppointmentTime appointmentTime;
     private final String duration;
     private final String treatment;
     private long id;
+    private String dentistName;
+    private String patientName;
 
     /**
      * Constructs an Appointment with the specified details.
      *
-     * @param dentist The name of the dentist for the appointment.
-     * @param patient The name of the patient for the appointment.
+     * @param dentistId The name of the dentist for the appointment.
+     * @param patientId The name of the patient for the appointment.
      * @param appointmentTime The time and date of the appointment.
      * @param duration The duration of the appointment.
      * @param treatment The treatment provided.
      */
-    public Appointment(long dentist, long patient, AppointmentTime appointmentTime,
+    public Appointment(long dentistId, long patientId, AppointmentTime appointmentTime,
                        String duration, String treatment) {
-        this.dentist = dentist;
-        this.patient = patient;
+        this.dentistId = dentistId;
+        this.patientId = patientId;
         this.appointmentTime = appointmentTime;
         this.duration = duration;
         this.treatment = treatment;
@@ -33,31 +39,46 @@ public class Appointment {
     /**
      * Constructs an Appointment with the specified details.
      *
-     * @param dentist The name of the dentist for the appointment.
-     * @param patient The name of the patient for the appointment.
+     * @param dentistId The name of the dentist for the appointment.
+     * @param patientId The name of the patient for the appointment.
      * @param appointmentTime The time and date of the appointment.
      * @param duration The duration of the appointment.
      * @param treatment The treatment provided.
      * @param id The appointment id.
      */
-    public Appointment(long dentist, long patient, AppointmentTime appointmentTime,
+    public Appointment(long dentistId, long patientId, AppointmentTime appointmentTime,
                        String duration, String treatment, long id) {
-        this.dentist = dentist;
-        this.patient = patient;
+        this.dentistId = dentistId;
+        this.patientId = patientId;
         this.appointmentTime = appointmentTime;
         this.duration = duration;
         this.treatment = treatment;
         this.id = id;
     }
 
-    public long getDentist() {
-        return this.dentist;
+    public long getDentistId() {
+        return this.dentistId;
     }
 
-    public long getPatient() {
-        return this.patient;
+    public long getPatientId() {
+        return this.patientId;
     }
 
+    public void setDentistName(String dentistName) {
+        this.dentistName = dentistName;
+    }
+
+    public void setPatientName(String patientName) {
+        this.patientName = patientName;
+    }
+
+    public String getDentistName() {
+        return this.dentistName;
+    }
+
+    public String getPatientName() {
+        return this.patientName;
+    }
     public String getDuration() {
         return this.duration;
     }

--- a/src/main/java/seedu/address/model/appointments/Appointment.java
+++ b/src/main/java/seedu/address/model/appointments/Appointment.java
@@ -4,8 +4,8 @@ package seedu.address.model.appointments;
  * Represents an Appointment in ToothTracker.
  */
 public class Appointment {
-    private final String dentist;
-    private final String patient;
+    private final long dentist;
+    private final long patient;
     private final AppointmentTime appointmentTime;
     private final String duration;
     private final String treatment;
@@ -20,7 +20,7 @@ public class Appointment {
      * @param duration The duration of the appointment.
      * @param treatment The treatment provided.
      */
-    public Appointment(String dentist, String patient, AppointmentTime appointmentTime,
+    public Appointment(long dentist, long patient, AppointmentTime appointmentTime,
                        String duration, String treatment) {
         this.dentist = dentist;
         this.patient = patient;
@@ -39,7 +39,7 @@ public class Appointment {
      * @param duration The duration of the appointment.
      * @param treatment The treatment provided.
      */
-    public Appointment(String dentist, String patient, AppointmentTime appointmentTime,
+    public Appointment(long dentist, long patient, AppointmentTime appointmentTime,
                        String duration, String treatment, long id) {
         this.dentist = dentist;
         this.patient = patient;
@@ -49,11 +49,11 @@ public class Appointment {
         this.id = id;
     }
 
-    public String getDentist() {
+    public long getDentist() {
         return this.dentist;
     }
 
-    public String getPatient() {
+    public long getPatient() {
         return this.patient;
     }
 

--- a/src/main/java/seedu/address/model/appointments/Appointment.java
+++ b/src/main/java/seedu/address/model/appointments/Appointment.java
@@ -1,9 +1,5 @@
 package seedu.address.model.appointments;
 
-import seedu.address.model.person.Name;
-import seedu.address.model.person.dentist.Dentist;
-import seedu.address.model.person.patients.Patient;
-
 /**
  * Represents an Appointment in ToothTracker.
  */

--- a/src/main/java/seedu/address/model/appointments/Appointment.java
+++ b/src/main/java/seedu/address/model/appointments/Appointment.java
@@ -38,6 +38,7 @@ public class Appointment {
      * @param appointmentTime The time and date of the appointment.
      * @param duration The duration of the appointment.
      * @param treatment The treatment provided.
+     * @param id The appointment id.
      */
     public Appointment(long dentist, long patient, AppointmentTime appointmentTime,
                        String duration, String treatment, long id) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
@@ -49,8 +49,8 @@ public class JsonAdaptedAppointment {
      * @param source The source appointment to be adapted.
      */
     public JsonAdaptedAppointment(Appointment source) {
-        dentist = source.getDentist();
-        patient = source.getPatient();
+        dentist = String.valueOf(source.getDentist());
+        patient = String.valueOf(source.getPatient());
         start = source.getAppointmentTime().startToString();
         duration = source.getAppointmentTime().durationToString();
         treatment = source.getTreatment();
@@ -68,10 +68,12 @@ public class JsonAdaptedAppointment {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
+        long dentistId = Long.parseLong(dentist);
         if (patient == null) {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
+        long patientId = Long.parseLong(patient);
         if (start == null) {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
@@ -91,6 +93,6 @@ public class JsonAdaptedAppointment {
         long lid = Long.parseLong(id);
 
         final AppointmentTime appointmentTime = new AppointmentTime(start, duration);
-        return new Appointment(dentist, patient, appointmentTime, duration, treatment, lid);
+        return new Appointment(dentistId, patientId, appointmentTime, duration, treatment, lid);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
@@ -33,11 +33,14 @@ public class JsonAdaptedAppointment {
      * @param treatment The treatment provided during the appointment.
      */
     @JsonCreator
-    public JsonAdaptedAppointment(@JsonProperty("dentistId") String dentistId, @JsonProperty("patientId") String patientId,
+    public JsonAdaptedAppointment(@JsonProperty("dentistId") String dentistId,
+                                  @JsonProperty("patientId") String patientId,
                                   @JsonProperty("dentistName") String dentistName,
                                   @JsonProperty("patientName") String patientName,
-                                  @JsonProperty("start") String start, @JsonProperty("duration") String duration,
-                                  @JsonProperty("treatment") String treatment, @JsonProperty("id") String id) {
+                                  @JsonProperty("start") String start,
+                                  @JsonProperty("duration") String duration,
+                                  @JsonProperty("treatment") String treatment,
+                                  @JsonProperty("id") String id) {
         this.dentistId = dentistId;
         this.patientId = patientId;
         this.dentistName = dentistName;

--- a/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
@@ -14,8 +14,10 @@ import seedu.address.model.person.Name;
 public class JsonAdaptedAppointment {
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Appointment's %s field is missing!";
 
-    private final String dentist;
-    private final String patient;
+    private final String dentistId;
+    private final String patientId;
+    private final String dentistName;
+    private final String patientName;
     private final String start;
     private final String duration;
     private final String treatment;
@@ -24,18 +26,22 @@ public class JsonAdaptedAppointment {
     /**
      * Constructs a {@code JsonAdaptedAppointment} with the given appointment details.
      *
-     * @param dentist The dentist's name.
-     * @param patient The patient's name.
+     * @param dentistId The dentist's name.
+     * @param patientId The patient's name.
      * @param start The start time of the appointment in string format.
      * @param duration The duration of the appointment in string format.
      * @param treatment The treatment provided during the appointment.
      */
     @JsonCreator
-    public JsonAdaptedAppointment(@JsonProperty("dentist") String dentist, @JsonProperty("patient") String patient,
-                             @JsonProperty("start") String start, @JsonProperty("duration") String duration,
+    public JsonAdaptedAppointment(@JsonProperty("dentistId") String dentistId, @JsonProperty("patientId") String patientId,
+                                  @JsonProperty("dentistName") String dentistName,
+                                  @JsonProperty("patientName") String patientName,
+                                  @JsonProperty("start") String start, @JsonProperty("duration") String duration,
                                   @JsonProperty("treatment") String treatment, @JsonProperty("id") String id) {
-        this.dentist = dentist;
-        this.patient = patient;
+        this.dentistId = dentistId;
+        this.patientId = patientId;
+        this.dentistName = dentistName;
+        this.patientName = patientName;
         this.start = start;
         this.duration = duration;
         this.treatment = treatment;
@@ -49,8 +55,10 @@ public class JsonAdaptedAppointment {
      * @param source The source appointment to be adapted.
      */
     public JsonAdaptedAppointment(Appointment source) {
-        dentist = String.valueOf(source.getDentist());
-        patient = String.valueOf(source.getPatient());
+        dentistId = String.valueOf(source.getDentistId());
+        patientId = String.valueOf(source.getPatientId());
+        dentistName = source.getDentistName();
+        patientName = source.getPatientName();
         start = source.getAppointmentTime().startToString();
         duration = source.getAppointmentTime().durationToString();
         treatment = source.getTreatment();
@@ -64,16 +72,24 @@ public class JsonAdaptedAppointment {
      * @throws IllegalValueException If there were any data constraints violated in the adapted appointment.
      */
     public Appointment toModelType() throws IllegalValueException {
-        if (dentist == null) {
+        if (dentistId == null) {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
-        long dentistId = Long.parseLong(dentist);
-        if (patient == null) {
+        long did = Long.parseLong(dentistId);
+        if (patientId == null) {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
-        long patientId = Long.parseLong(patient);
+        long pid = Long.parseLong(patientId);
+        if (dentistName == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
+        if (patientName == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
+        }
         if (start == null) {
             throw new IllegalValueException(
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
@@ -93,6 +109,9 @@ public class JsonAdaptedAppointment {
         long lid = Long.parseLong(id);
 
         final AppointmentTime appointmentTime = new AppointmentTime(start, duration);
-        return new Appointment(dentistId, patientId, appointmentTime, duration, treatment, lid);
+        Appointment newAppointment = new Appointment(did, pid, appointmentTime, duration, treatment, lid);
+        newAppointment.setDentistName(dentistName);
+        newAppointment.setPatientName(patientName);
+        return newAppointment;
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedAppointment.java
@@ -106,8 +106,7 @@ public class JsonAdaptedAppointment {
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
         if (id == null) {
-            throw new IllegalValueException(
-                    "id value does not exist!");
+            throw new IllegalValueException("id value does not exist!");
         }
         long lid = Long.parseLong(id);
 

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -107,9 +107,9 @@ class JsonSerializableAddressBook {
 
         for (JsonAdaptedAppointment jsonAdaptedAppointment : appointments) {
             Appointment appointment = jsonAdaptedAppointment.toModelType();
-//            if (addressBook.hasAppointment(appointment)) {
-//                throw new IllegalValueException(MESSAGE_CLASHING_APPOINTMENTS);
-//            }
+            /*if (addressBook.hasAppointment(appointment)) {
+                throw new IllegalValueException(MESSAGE_CLASHING_APPOINTMENTS);
+            }*/
             addressBook.addAppointment(appointment);
         }
 

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -104,9 +104,9 @@ class JsonSerializableAddressBook {
 
         for (JsonAdaptedAppointment jsonAdaptedAppointment : appointments) {
             Appointment appointment = jsonAdaptedAppointment.toModelType();
-            if (addressBook.hasAppointment(appointment)) {
-                throw new IllegalValueException(MESSAGE_CLASHING_APPOINTMENTS);
-            }
+//            if (addressBook.hasAppointment(appointment)) {
+//                throw new IllegalValueException(MESSAGE_CLASHING_APPOINTMENTS);
+//            }
             addressBook.addAppointment(appointment);
         }
 

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -123,6 +123,7 @@ class JsonSerializableAddressBook {
 
         addressBook.setDentistId(Long.parseLong(dentistId));
         addressBook.setPatientId(Long.parseLong(patientId));
+        addressBook.setAppointmentId(Long.parseLong(appointmentId));
         return addressBook;
     }
 

--- a/src/main/java/seedu/address/ui/AppointmentCard.java
+++ b/src/main/java/seedu/address/ui/AppointmentCard.java
@@ -37,8 +37,8 @@ public class AppointmentCard extends UiPart<Region> {
     public AppointmentCard(Appointment appointment) {
         super(FXML);
         this.appointment = appointment;
-        dentist.setText("Dentist: " + appointment.getDentist());
-        patient.setText("Patient: " + appointment.getPatient());
+        dentist.setText("Dentist: " + appointment.getDentistName());
+        patient.setText("Patient: " + appointment.getPatientName());
         appointmentTime.setText(appointment.getAppointmentTime().appointmentTimeToString());
         date.setText(appointment.getAppointmentTime().dateToString());
         service.setText("Treatment: " + appointment.getTreatment());

--- a/src/test/data/JsonSerializableAddressBookTest/typicalDentistsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalDentistsAddressBook.json
@@ -66,5 +66,6 @@
     "tags" : [ "America" ]
   } ],
   "patientId" : "6",
-  "dentistId" : "7"
+  "dentistId" : "7",
+  "appointmentId" : "5"
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -45,5 +45,6 @@
   } ],
   "dentists": [],
   "patientId" : "6",
-  "dentistId" : "6"
+  "dentistId" : "6",
+  "appointmentId" : "5"
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -200,6 +200,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void updateFilteredAppointmentList(Predicate<Appointment> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Patient> getFilteredPatientList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/AddDentistCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddDentistCommandTest.java
@@ -203,6 +203,11 @@ public class AddDentistCommandTest {
         }
 
         @Override
+        public void updateFilteredAppointmentList(Predicate<Appointment> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Patient> getFilteredPatientList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -94,8 +94,9 @@ public class AddressBookTest {
         String expected =
             AddressBook.class.getCanonicalName() + "{persons=" + addressBook.getPersonList()
                 + ", patients=" + addressBook.getPatientList()
-                + ", dentists=" + addressBook.getDentistList() + ", treatments="
-                + addressBook.getTreatmentList() + "}";
+                + ", dentists=" + addressBook.getDentistList()
+                + ", appointments=" + addressBook.getAppointmentList()
+                + ", treatments=" + addressBook.getTreatmentList() + "}";
         assertEquals(expected, addressBook.toString());
     }
 


### PR DESCRIPTION
- add-appointment now checks whether dentist or patient exists in ToothTracker before adding
- If appointment added has another appointment in same time slot, checks whether the dentist or patient are the same. If they are not the same, the appointment can still be added. Otherwise, appointment cannot be added.
- Treatment and duration are still taken in as 2 separate strings. (Treatment class not taken in)
- fixed error for appointment id