### PR TITLE
Update add-patient example fields

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -247,20 +247,14 @@ Adds a patient to the list of patients in ToothTracker. This is helpful when:
 - You are using ToothTracker for the first time and you have to add your patients' particulars.
 - A new patient has joined your clinic.
 
-Format: `add-patient n/NAME p/PHONE e/EMAIL b/BIRTHDATE g/GENDER r/REMARK s/SERVICE h/ADDRESS `
+Format: `add-patient n/NAME p/PHONE b/BIRTHDATE g/GENDER [r/REMARK] [tr/TREATMENT] [e/EMAIL] [h/ADDRESS] ADDRESS] [t/TAG] `
 
 Examples:
 
-* `Add-patient n/John Tan p/90676622 e/johntan@gmail.com b/06-06-1998 g/M r/heavy smoker s/Cleaning h/60 Jalan Kempinski Road` <br>
-Adds a new patient named ‘John Tan’, with phone number ‘90676622’ and email of ‘johntan@gmail.com’,
-birthdate of 06 June 1998, Gender Male, remark that he is a heavy smoker, requesting for cleaning treatment
-and with an address at 60 Jalan Kempinski Road.
-
-
-* `Add-patient n/Megan Chua p/88756298 e/megan@outlook.com b/10-09-1993 g/F s/Cleaning h/34 Changi Rise` <br>
-Adds a new patient named ‘Megan Chua’, with phone number ‘88756298’ and email of ‘megan@outlook.com’,
-birthdate of 10 Sep 1993, Gender Female, no remark specified, requesting for cleaning treatment and with
-an address at 34 Changi Rise.
+* `add-patient n/John p/90676622 b/06-06-1998 g/M r/Allergic to Peanuts tr/Braces e/johntan@gmail.com h/60 Harvey Avenue t/Urgent` <br>
+Adds a new patient named ‘John’, with phone number ‘90676622’ and email of ‘johntan@gmail.com’,
+birthdate of 06 June 1998, Gender Male, remark that he is allergic to Peanuts, requesting for cleaning treatment
+and with an address at 60 Harvey Avenue.
 
 ### Listing all patients : `list-patient`
 
@@ -524,31 +518,31 @@ Afterwards, you may edit the particulars using `edit-dentist` or `edit-patient` 
 
 ## Command summary
 
-| Action                           | Format, Examples                                                                                                                                                                                                                               |
-|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Add Dentist**                  | `add-dentist n/NAME p/PHONE s/SPECIALIZATION y/YOE [e/EMAIL] [h/ADDRESS] [t/TAG]…​` <br> e.g., `add-dentist n/Bob p/12345678 e/bobjune@gmail.com y/6 s/braces`                                                                                 |
-| **Edit Dentist**                 | `edit-dentist DENTIST_ID [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SPECIALIZATION] [y/YOE] [t/TAG]…​` <br> e.g., `edit-dentist 1 p/98987676 e/bobjuly@gmail.com`                                                                             |
-| **Delete Dentist**               | `delete-dentist DENTIST_ID`<br> e.g., `delete-dentist 3`                                                                                                                                                                                       |
-| **List Dentist**                 | `list-dentist`                                                                                                                                                                                                                                 |
-| **Search Dentist by Dentist ID** | `search-dentist DENTIST_ID` <br> e.g., `search-dentist 2`                                                                                                                                                                                      |
-| **Search Dentist by Keyword**    | `search-dentist KEYWORD` <br> e.g., `search-dentist Tom`                                                                                                                                                                                       |
-| **Filter Dentist**               | `filter-dentist a/ATTRIBUTE k/KEYWORDS` <br> e.g., `filter-dentist a/phone k/90182211`                                                                                                                                                         |
-| **Add Patient**                  | `add-patient n/NAME p/PHONE b/BIRTHDATE g/GENDER s/SERVICE [e/EMAIL] [h/ADDRESS] [r/REMARK] [t/TAG]…​` <br> e.g., `add-patient n/John Tan p/90676622 e/johntan@gmail.com b/06-06-1998 g/M r/corn allergy s/Cleaning h/60 Jalan Kempinski Road` |
-| **Delete Patient**               | `delete-patient PATIENT_ID`<br> e.g., `delete-patient 3`                                                                                                                                                                                       |
-| **List Patient**                 | `list-patient`                                                                                                                                                                                                                                 |
-| **Search Patient by Patient ID** | `search-patient PATIENT_ID`  <br> e.g., `search-patient 3`                                                                                                                                                                                     |
-| **Search Patient by Keyword**    | `search-patient KEYWORD` <br> e.g., `search-patient John`                                                                                                                                                                                      |
-| **Filter Patient**               | `filter-patient a/ATTRIBUTE k/KEYWORDS` <br> e.g., `filter-patient a/phone k/98776211`                                                                                                                                                         |
-| **Add Treatment**                | `add-treatment tr/NAME cs/PRICE ti/DURATION` <br> e.g., `add-treatment tr/Tooth Extraction cs/150 ti/01:00`                                                                                                                                    |
-| **Delete Treatment**             | `delete-treatment NAME` <br> e.g., `delete-treatment Braces`                                                                                                                                                                                   |
-| **List Treatment**               | `list-treatment`                                                                                                                                                                                                                               |
-| **Add Appointment**              | `add-appointment dentist/DENTIST_ID patient/PATIENT_ID start/START_TIME s/TREATMENT` <br> e.g.,`add-appointment dentist/0 patient/0 start/2023-10-12 16:00 s/Braces`                                        |
-| **Delete Appointment**           | `delete-appointment APPOINTMENT_ID`<br> e.g., `delete-appointment 3`                                                                                                                                                                           |
-| **List Appointment**             | `list-appointment`                                                                                                                                                                                                                             |
-| **Filter Appointment by Dentist ID** | `filter-appointment dentist DENTIST_ID` <br> e.g., `filter-appointment dentist 1`                                                                                                                                                              |
-| **Filter Appointment by Patient ID** | `filter-appointment patient PATIENT_ID` <br> e.g., `filter-appointment patient 1`                                                                                                                                                              |
-| **Clear all Profiles**           | `clear`                                                                                                                                                                                                                                        |
-| **Exit Programme**               | `exit`                                                                                                                                                                                                                                         |
-| **Help**                         | `help`                                                                                                                                                                                                                                         |
+| Action                           | Format, Examples                                                                                                                                                                                                                                    |
+|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Add Dentist**                  | `add-dentist n/NAME p/PHONE s/SPECIALIZATION y/YOE [e/EMAIL] [h/ADDRESS] [t/TAG]…​` <br> e.g., `add-dentist n/Bob p/12345678 e/bobjune@gmail.com y/6 s/braces`                                                                                      |
+| **Edit Dentist**                 | `edit-dentist DENTIST_ID [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [s/SPECIALIZATION] [y/YOE] [t/TAG]…​` <br> e.g., `edit-dentist 1 p/98987676 e/bobjuly@gmail.com`                                                                                  |
+| **Delete Dentist**               | `delete-dentist DENTIST_ID`<br> e.g., `delete-dentist 3`                                                                                                                                                                                            |
+| **List Dentist**                 | `list-dentist`                                                                                                                                                                                                                                      |
+| **Search Dentist by Dentist ID** | `search-dentist DENTIST_ID` <br> e.g., `search-dentist 2`                                                                                                                                                                                           |
+| **Search Dentist by Keyword**    | `search-dentist KEYWORD` <br> e.g., `search-dentist Tom`                                                                                                                                                                                            |
+| **Filter Dentist**               | `filter-dentist a/ATTRIBUTE k/KEYWORDS` <br> e.g., `filter-dentist a/phone k/90182211`                                                                                                                                                              |
+| **Add Patient**                  | `add-patient n/NAME p/PHONE b/BIRTHDATE g/GENDER s/SERVICE [e/EMAIL] [h/ADDRESS] [r/REMARK] [t/TAG]…​` <br> e.g., `add-patient n/John p/90676622 b/06-06-1998 g/M r/Allergic to Peanuts tr/Braces e/johntan@gmail.com h/60 Harvey Avenue t/Urgent`  | 
+| **Delete Patient**               | `delete-patient PATIENT_ID`<br> e.g., `delete-patient 3`                                                                                                                                                                                            |
+| **List Patient**                 | `list-patient`                                                                                                                                                                                                                                      |
+| **Search Patient by Patient ID** | `search-patient PATIENT_ID`  <br> e.g., `search-patient 3`                                                                                                                                                                                          |
+| **Search Patient by Keyword**    | `search-patient KEYWORD` <br> e.g., `search-patient John`                                                                                                                                                                                           |
+| **Filter Patient**               | `filter-patient a/ATTRIBUTE k/KEYWORDS` <br> e.g., `filter-patient a/phone k/98776211`                                                                                                                                                              |
+| **Add Treatment**                | `add-treatment tr/NAME cs/PRICE ti/DURATION` <br> e.g., `add-treatment tr/Tooth Extraction cs/150 ti/01:00`                                                                                                                                         |
+| **Delete Treatment**             | `delete-treatment NAME` <br> e.g., `delete-treatment Braces`                                                                                                                                                                                        |
+| **List Treatment**               | `list-treatment`                                                                                                                                                                                                                                    |
+| **Add Appointment**              | `add-appointment dentist/DENTIST_ID patient/PATIENT_ID start/START_TIME s/TREATMENT` <br> e.g.,`add-appointment dentist/0 patient/0 start/2023-10-12 16:00 s/Braces`                                                                                |
+| **Delete Appointment**           | `delete-appointment APPOINTMENT_ID`<br> e.g., `delete-appointment 3`                                                                                                                                                                                |
+| **List Appointment**             | `list-appointment`                                                                                                                                                                                                                                  |
+| **Filter Appointment by Dentist ID** | `filter-appointment dentist DENTIST_ID` <br> e.g., `filter-appointment dentist 1`                                                                                                                                                                   |
+| **Filter Appointment by Patient ID** | `filter-appointment patient PATIENT_ID` <br> e.g., `filter-appointment patient 1`                                                                                                                                                                   |
+| **Clear all Profiles**           | `clear`                                                                                                                                                                                                                                             |
+| **Exit Programme**               | `exit`                                                                                                                                                                                                                                              |
+| **Help**                         | `help`                                                                                                                                                                                                                                              |
 
 

--- a/src/main/java/seedu/address/logic/commands/AddPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPatientCommand.java
@@ -31,10 +31,10 @@ public class AddPatientCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_BIRTHDATE + "BIRTHDATE "
             + PREFIX_GENDER + "GENDER "
-            + PREFIX_REMARK + "REMARK "
-            + PREFIX_TREATMENT + "TREATMENT "
-            + PREFIX_EMAIL + "EMAIL "
-            + PREFIX_ADDRESS + "ADDRESS "
+            + "[" + PREFIX_REMARK + "REMARK] "
+            + "[" + PREFIX_TREATMENT + "TREATMENT] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John "
@@ -49,6 +49,7 @@ public class AddPatientCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New Patient added: %1$s";
     public static final String MESSAGE_DUPLICATE_PATIENT = "This Patient already exists in ToothTracker";
+    public static final String MESSAGE_INVALID_TREATMENT = "This treatment is invalid";
 
     private final Patient toAdd;
 
@@ -66,6 +67,11 @@ public class AddPatientCommand extends Command {
 
         if (model.hasPatient(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PATIENT);
+        }
+
+        String treatmentName = toAdd.getTreatmentName().toString();
+        if (!model.hasTreatmentName(toAdd.getTreatmentName()) && !treatmentName.equals("NIL")) {
+            throw new CommandException(MESSAGE_INVALID_TREATMENT);
         }
 
         model.addPatient(toAdd);

--- a/src/main/java/seedu/address/logic/commands/AddPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPatientCommand.java
@@ -42,7 +42,7 @@ public class AddPatientCommand extends Command {
             + PREFIX_BIRTHDATE + "06-06-1998 "
             + PREFIX_GENDER + "M "
             + PREFIX_REMARK + "Allergic to Peanuts "
-            + PREFIX_TREATMENT + "Cleaning "
+            + PREFIX_TREATMENT + "Braces "
             + PREFIX_EMAIL + "johntan@gmail.com "
             + PREFIX_ADDRESS + "60 Harvey Avenue "
             + PREFIX_TAG + "Urgent";

--- a/src/main/java/seedu/address/logic/commands/EditPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPatientCommand.java
@@ -91,7 +91,7 @@ public class EditPatientCommand extends Command {
             }
             Patient editedPatient = createEditedPatient(patientToEdit, editPatientDescriptor);
 
-            if (!patientToEdit.isSamePerson(editedPatient) && model.hasPerson(editedPatient)) {
+            if (!patientToEdit.isSamePatient(editedPatient) && model.hasPatient(editedPatient)) {
                 throw new CommandException(MESSAGE_DUPLICATE_PATIENT);
             }
 
@@ -101,9 +101,7 @@ public class EditPatientCommand extends Command {
                 String.format(MESSAGE_EDIT_PATIENT_SUCCESS, Messages.format(editedPatient)));
 
         } catch (Exception e) {
-            throw new CommandException(
-                "An error occurred while editing the patient: " + e.getMessage()
-                    + " Please use list-patients or search-patient to get the intended Patient on the screen first.");
+            throw new CommandException(e.getMessage());
         }
 
     }

--- a/src/main/java/seedu/address/logic/parser/AddPatientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPatientCommandParser.java
@@ -54,12 +54,13 @@ public class AddPatientCommandParser implements Parser<AddPatientCommand> {
         if (!arePrefixesPresent(argMultimap,
             PREFIX_NAME,
             PREFIX_PHONE,
-            // PREFIX_BIRTHDATE,
+            PREFIX_BIRTHDATE,
             // PREFIX_REMARK,
             // PREFIX_TREATMENT,
             // PREFIX_ADDRESS,
             // PREFIX_EMAIL,
-            PREFIX_GENDER)
+            PREFIX_GENDER
+        )
             || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPatientCommand.MESSAGE_USAGE));
@@ -77,17 +78,26 @@ public class AddPatientCommandParser implements Parser<AddPatientCommand> {
             PREFIX_EMAIL);
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+
         Birthdate birthdate = ParserUtil.parseBirthdate(
             argMultimap.getValue(PREFIX_BIRTHDATE).get());
-        Gender gender = ParserUtil.parseGender(argMultimap.getValue(PREFIX_GENDER).orElse("NA"));
+
+        Gender gender = ParserUtil.parseGender(argMultimap.getValue(PREFIX_GENDER).get());
+
         Remark remark = ParserUtil.parseRemark(
             argMultimap.getValue(PREFIX_REMARK).orElse("NIL"));
-        TreatmentName treatmentName = ParserUtil.parseTreatmentName(argMultimap.getValue(PREFIX_TREATMENT).get());
+
+        TreatmentName treatmentName = ParserUtil.parseTreatmentName(
+            argMultimap.getValue(PREFIX_TREATMENT).orElse("NIL"));
+
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL)
             .orElse("NoEmailProvided@ToBeAdded.com"));
+
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS)
             .orElse("No Address Provided."));
+
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Patient patient = new Patient(name, phone, birthdate, gender, remark, treatmentName,

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -51,7 +51,17 @@ public class SampleDataUtil {
     public static Treatment[] getSampleTreatments() {
         return new Treatment[]{
             new Treatment(new TreatmentName("Braces"), new TreatmentCost("1080"),
-                new TreatmentTime("03:00"))
+                new TreatmentTime("03:00")),
+            new Treatment(new TreatmentName("Whitening"), new TreatmentCost("999"),
+                new TreatmentTime("01:30")),
+            new Treatment(new TreatmentName("WisdomTooth"), new TreatmentCost("1050"),
+                new TreatmentTime("02:00")),
+            new Treatment(new TreatmentName("Scaling"), new TreatmentCost("9999"),
+                new TreatmentTime("03:00")),
+            new Treatment(new TreatmentName("Root Canal"), new TreatmentCost("1432"),
+                new TreatmentTime("05:00")),
+            new Treatment(new TreatmentName("Polishing"), new TreatmentCost("4000"),
+                new TreatmentTime("04:00"))
         };
     }
 


### PR DESCRIPTION
add-patient now follows this logic: 

Treatment changes
- Preload some Treatment objects in Sample Data 
- Make Treatment field Optional in add-patient command
- Update UG to guide testers
    Case 1: Use predefined Treatements => Can straight away use add-patient
    Case 2: Want to use another treatment => Do add-treatment first then add-patient

